### PR TITLE
bug fix of btor2aiger in PR #27

### DIFF
--- a/src/btor2aiger.cpp
+++ b/src/btor2aiger.cpp
@@ -423,6 +423,7 @@ add_state_to_aiger (Btor *btor,
         reset_val = init_bits ? init_bits[i] : state_bits[i];
         aiger_add_reset (aig, state_bits[i], reset_val);
       } else {
+        aiger_add_reset (aig, state_bits[i], state_bits[i]);
         init_constrains.push_back(std::make_pair(state_bits[i], init_bits[i]));
       }
     }


### PR DESCRIPTION
The bug is in https://github.com/gipsyh/rIC3/issues/5

When setting a latch to any expression via a constraint, its init value should be explicitly set to "X"; otherwise, it will be "0".